### PR TITLE
Make network API mockable and add test cases

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
+import 'package:holidays/networking/api.dart';
 import 'package:holidays/redux/app/app_reducers.dart';
 import 'package:holidays/redux/app/app_state.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
@@ -13,7 +14,7 @@ class HolidaysApp extends StatelessWidget {
   final Store<AppState> store = Store<AppState>(
     appReducer,
     initialState: AppState.initial(),
-    middleware: createHolidayListMiddleware(),
+    middleware: createHolidayListMiddleware(API()),
   );
 
   HolidaysApp() {

--- a/lib/networking/api.dart
+++ b/lib/networking/api.dart
@@ -1,0 +1,23 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:holidays/model/holiday_summary.dart';
+
+class API {
+  Future<List<HolidaySummary>> fetchHolidaySummaries() async {
+    // we'd normally call out to a network server of some kind, but for now,
+    // we'll just pause for a bit
+    await Future.delayed(const Duration(seconds: 1));
+
+    // to let us build and test our retry logic, sometimes we'll return
+    // some holiday summaries and sometimes we'll return an error
+    if (Random().nextBool()) {
+      final summary1 = HolidaySummary(id: 1, name: 'Europe');
+      final summary2 = HolidaySummary(id: 2, name: 'America');
+
+      return Future.value([summary1, summary2]);
+    } else {
+      throw StateError("Network timed out");
+    }
+  }
+}

--- a/lib/redux/holiday_list/holiday_list_middleware.dart
+++ b/lib/redux/holiday_list/holiday_list_middleware.dart
@@ -1,36 +1,27 @@
-import 'dart:async';
-import 'dart:math';
-
 import 'package:holidays/model/fetchable.dart';
-import 'package:holidays/model/holiday_summary.dart';
+import 'package:holidays/networking/api.dart';
 import 'package:holidays/redux/app/app_state.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
 import 'package:redux/redux.dart';
 
-List<Middleware<AppState>> createHolidayListMiddleware() => [
-      TypedMiddleware<AppState, FetchHolidaySummariesAction>(_fetchHolidaySummaries),
+List<Middleware<AppState>> createHolidayListMiddleware(API api) => [
+      TypedMiddleware<AppState, FetchHolidaySummariesAction>(_fetchHolidaySummaries(api)),
     ];
 
-Future _fetchHolidaySummaries(Store<AppState> store, FetchHolidaySummariesAction action, NextDispatcher next) async {
-  next(action);
+Middleware<AppState> _fetchHolidaySummaries(API api) {
+  return (Store<AppState> store, action, NextDispatcher next) async {
+    next(action);
 
-  if (action is FetchHolidaySummariesAction) {
-    // we'd normally call out to a repository of some kind, but for now,
-    // we'll just pause for a bit
-    await Future.delayed(const Duration(seconds: 1));
+    if (action is FetchHolidaySummariesAction) {
+      try {
+        final summaries = await api.fetchHolidaySummaries();
 
-    // let the UI know that we're back from the network
-    action.completer.complete();
-
-    // to let us build and test our retry logic, sometimes we'll return
-    // some holiday summaries and sometimes we'll return an error
-    if (Random().nextBool()) {
-      final summary1 = HolidaySummary(id: 1, name: 'Europe');
-      final summary2 = HolidaySummary(id: 2, name: 'America');
-
-      next(ReceivedHolidaySummariesAction(Fetchable.success([summary1, summary2])));
-    } else {
-      next(ReceivedHolidaySummariesAction(Fetchable.error(StateError("Network timed out"))));
+        action.completer.complete();
+        store.dispatch(ReceivedHolidaySummariesAction(Fetchable.success(summaries)));
+      } catch (e) {
+        action.completer.completeError(e);
+        store.dispatch(ReceivedHolidaySummariesAction(Fetchable.error(e)));
+      }
     }
-  }
+  };
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -186,6 +186,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.6+2"
+  mockito:
+    dependency: "direct dev"
+    description:
+      name: mockito
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   multi_server_socket:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  mockito: ^3.0.0
 
 
 flutter:

--- a/test/holiday_list_test.dart
+++ b/test/holiday_list_test.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+
+import 'package:holidays/model/fetchable.dart';
+import 'package:holidays/model/holiday_summary.dart';
+import 'package:holidays/redux/app/app_reducers.dart';
+import 'package:holidays/redux/app/app_state.dart';
+import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
+import 'package:holidays/redux/holiday_list/holiday_list_middleware.dart';
+import 'package:mockito/mockito.dart';
+import 'package:redux/redux.dart';
+import 'package:test/test.dart';
+
+import 'mocks.dart';
+
+void main() {
+  MockAPI mockAPI;
+  Store<AppState> store;
+
+  setUp(() {
+    mockAPI = MockAPI();
+
+    store = Store<AppState>(
+      appReducer,
+      initialState: AppState.initial(),
+      middleware: createHolidayListMiddleware(mockAPI),
+    );
+  });
+
+  tearDown(() {});
+
+  test('initial state', () {
+    final state = AppState.initial();
+
+    expect(state.holidaySummariesState.fetchableHolidaySummaries is FetchableSuccess<List<HolidaySummary>>, isTrue);
+  });
+
+  test('fetch holiday summaries', () async {
+    when(mockAPI.fetchHolidaySummaries()).thenAnswer((_) {
+      return Future.value([
+        HolidaySummary(id: 1, name: 'test1'),
+        HolidaySummary(id: 2, name: 'test2'),
+        HolidaySummary(id: 3, name: 'test3'),
+      ].toList());
+    });
+
+    // important that this is invoked using await, otherwise the
+    // async calls deep in the middleware will not have time to
+    // complete before the tests finish.
+    // ignore: await_only_futures
+    await store.dispatch(FetchHolidaySummariesAction());
+
+    var list = store.state.holidaySummariesState.fetchableHolidaySummaries;
+    if (list is FetchableSuccess<List<HolidaySummary>>) {
+      expect(list.object[0].name, equals('test1'));
+      expect(list.object[1].name, equals('test2'));
+      expect(list.object[2].name, equals('test3'));
+    } else {
+      fail("Not expected type of FetchableSuccess<List<HolidaySummary>>");
+    }
+  });
+}

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -1,0 +1,4 @@
+import 'package:holidays/networking/api.dart';
+import 'package:mockito/mockito.dart';
+
+class MockAPI extends Mock implements API {}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,1 +1,0 @@
-void main() {}


### PR DESCRIPTION
Like all good developers, we should be writing code that is easy to test against. This PR makes a few changes to make this a little bit easier. In particular, it involves moving the network code out from the middleware layer into a new class called, imaginitively, `API` which runs asynchronously.

We've also added "mockito" as a dependency, and wrote a very simple test case that shows how we can provide a mock response for a given API call and construct a test that depends on that mock data.

No new features have been introduced here... purely some refactoring to make testing better.

