### PR TITLE
Fetch holiday, display spinner, transition to holiday screen

### DIFF
--- a/lib/model/holiday.dart
+++ b/lib/model/holiday.dart
@@ -1,0 +1,19 @@
+import 'package:meta/meta.dart';
+
+class Holiday {
+  final int id;
+  final String name;
+  final String details;
+
+  Holiday({
+    @required this.id,
+    @required this.name,
+    @required this.details,
+  });
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is Holiday && runtimeType == other.runtimeType && id == other.id && name == other.name && details == other.details;
+
+  @override
+  int get hashCode => id;
+}

--- a/lib/networking/api.dart
+++ b/lib/networking/api.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:holidays/model/holiday.dart';
 import 'package:holidays/model/holiday_summary.dart';
 
 class API {
@@ -18,6 +19,18 @@ class API {
       return Future.value([summary1, summary2]);
     } else {
       throw StateError("Network timed out");
+    }
+  }
+
+  Future<Holiday> fetchHoliday(int id) async {
+    // we'd normally call out to a network server of some kind, but for now,
+    // we'll just pause for a bit
+    await Future.delayed(const Duration(seconds: 1));
+
+    if (id == 1) {
+      return Future.value(Holiday(id: id, name: "Europe", details: "This is a European holiday"));
+    } else {
+      return Future.value(Holiday(id: id, name: "America", details: "This is an American holiday"));
     }
   }
 }

--- a/lib/redux/holiday_list/holiday_list_actions.dart
+++ b/lib/redux/holiday_list/holiday_list_actions.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:holidays/model/fetchable.dart';
+import 'package:holidays/model/holiday.dart';
 import 'package:holidays/model/holiday_summary.dart';
 
 class FetchHolidaySummariesAction {
@@ -12,4 +13,23 @@ class ReceivedHolidaySummariesAction {
   final Fetchable<List<HolidaySummary>> fetchableHolidaySummaries;
 
   ReceivedHolidaySummariesAction(this.fetchableHolidaySummaries);
+}
+
+class FetchHolidayAction {
+  final int id;
+  final Completer completer;
+  FetchHolidayAction(this.id) : this.completer = Completer();
+}
+
+class ReceivedHolidayAction {
+  final Fetchable<Holiday> fetchableHoliday;
+
+  ReceivedHolidayAction(this.fetchableHoliday);
+}
+
+class SelectHolidayAction {
+  /// Select a specific holiday. Can be null if the action is to deselect.
+  final Holiday holiday;
+
+  SelectHolidayAction(this.holiday);
 }

--- a/lib/redux/holiday_list/holiday_list_middleware.dart
+++ b/lib/redux/holiday_list/holiday_list_middleware.dart
@@ -6,6 +6,7 @@ import 'package:redux/redux.dart';
 
 List<Middleware<AppState>> createHolidayListMiddleware(API api) => [
       TypedMiddleware<AppState, FetchHolidaySummariesAction>(_fetchHolidaySummaries(api)),
+      TypedMiddleware<AppState, FetchHolidayAction>(_fetchHoliday(api)),
     ];
 
 Middleware<AppState> _fetchHolidaySummaries(API api) {
@@ -21,6 +22,24 @@ Middleware<AppState> _fetchHolidaySummaries(API api) {
       } catch (e) {
         action.completer.completeError(e);
         store.dispatch(ReceivedHolidaySummariesAction(Fetchable.error(e)));
+      }
+    }
+  };
+}
+
+Middleware<AppState> _fetchHoliday(API api) {
+  return (Store<AppState> store, action, NextDispatcher next) async {
+    next(action);
+
+    if (action is FetchHolidayAction) {
+      try {
+        final holiday = await api.fetchHoliday(action.id);
+
+        action.completer.complete();
+        store.dispatch(ReceivedHolidayAction(Fetchable.success(holiday)));
+      } catch (e) {
+        action.completer.completeError(e);
+        store.dispatch(ReceivedHolidayAction(Fetchable.error(e)));
       }
     }
   };

--- a/lib/redux/holiday_list/holiday_list_reducers.dart
+++ b/lib/redux/holiday_list/holiday_list_reducers.dart
@@ -6,6 +6,9 @@ import 'package:redux/redux.dart';
 final holidaySummaryListReducer = combineReducers<HolidaySummariesState>([
   TypedReducer<HolidaySummariesState, FetchHolidaySummariesAction>(_fetchHolidaySummaries),
   TypedReducer<HolidaySummariesState, ReceivedHolidaySummariesAction>(_receivedHolidaySummaries),
+  TypedReducer<HolidaySummariesState, FetchHolidayAction>(_fetchHoliday),
+  TypedReducer<HolidaySummariesState, ReceivedHolidayAction>(_receivedHoliday),
+  TypedReducer<HolidaySummariesState, SelectHolidayAction>(_selectHoliday),
 ]);
 
 HolidaySummariesState _fetchHolidaySummaries(HolidaySummariesState state, FetchHolidaySummariesAction action) {
@@ -14,4 +17,20 @@ HolidaySummariesState _fetchHolidaySummaries(HolidaySummariesState state, FetchH
 
 HolidaySummariesState _receivedHolidaySummaries(HolidaySummariesState state, ReceivedHolidaySummariesAction action) {
   return state.copyWith(fetchableHolidaySummaries: action.fetchableHolidaySummaries);
+}
+
+HolidaySummariesState _fetchHoliday(HolidaySummariesState state, FetchHolidayAction action) {
+  return state.copyWith(fetchableCurrentHoliday: Fetchable.loading());
+}
+
+HolidaySummariesState _receivedHoliday(HolidaySummariesState state, ReceivedHolidayAction action) {
+  return state.copyWith(fetchableCurrentHoliday: action.fetchableHoliday);
+}
+
+HolidaySummariesState _selectHoliday(HolidaySummariesState state, SelectHolidayAction action) {
+  if (action.holiday == null) {
+    return state.copyWith(fetchableCurrentHoliday: null);
+  } else {
+    return state.copyWith(fetchableCurrentHoliday: Fetchable.success(action.holiday));
+  }
 }

--- a/lib/redux/holiday_list/holiday_list_state.dart
+++ b/lib/redux/holiday_list/holiday_list_state.dart
@@ -1,4 +1,5 @@
 import 'package:holidays/model/fetchable.dart';
+import 'package:holidays/model/holiday.dart';
 import 'package:holidays/model/holiday_summary.dart';
 import 'package:meta/meta.dart';
 
@@ -7,25 +8,35 @@ class HolidaySummariesState {
   /// A list of visible holiday summaries. Not expected to be null.
   final Fetchable<List<HolidaySummary>> fetchableHolidaySummaries;
 
-  HolidaySummariesState({@required this.fetchableHolidaySummaries});
+  /// The currently selected holiday. Can be null if no holiday is selected
+  /// or we're not in the process of fetching one.
+  final Fetchable<Holiday> fetchableCurrentHoliday;
+
+  HolidaySummariesState({
+    @required this.fetchableHolidaySummaries,
+    @required this.fetchableCurrentHoliday,
+  });
 
   factory HolidaySummariesState.initial() {
     return HolidaySummariesState(
       fetchableHolidaySummaries: Fetchable.success([]),
+      fetchableCurrentHoliday: null,
     );
   }
 
   HolidaySummariesState copyWith({
     Fetchable<List<HolidaySummary>> fetchableHolidaySummaries,
+    Fetchable<Holiday> fetchableCurrentHoliday,
   }) {
     return HolidaySummariesState(
       fetchableHolidaySummaries: fetchableHolidaySummaries ?? this.fetchableHolidaySummaries,
+      fetchableCurrentHoliday: fetchableCurrentHoliday ?? this.fetchableCurrentHoliday,
     );
   }
 
   @override
-  bool operator ==(Object other) => identical(this, other) || other is HolidaySummariesState && runtimeType == other.runtimeType && fetchableHolidaySummaries == other.fetchableHolidaySummaries;
+  bool operator ==(Object other) => identical(this, other) || other is HolidaySummariesState && runtimeType == other.runtimeType && fetchableHolidaySummaries == other.fetchableHolidaySummaries && fetchableCurrentHoliday == other.fetchableCurrentHoliday;
 
   @override
-  int get hashCode => fetchableHolidaySummaries.hashCode;
+  int get hashCode => fetchableHolidaySummaries.hashCode ^ fetchableCurrentHoliday.hashCode;
 }

--- a/lib/ui/holiday/holiday_screen.dart
+++ b/lib/ui/holiday/holiday_screen.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_redux/flutter_redux.dart';
+import 'package:holidays/model/fetchable.dart';
+import 'package:holidays/model/holiday.dart';
+import 'package:holidays/redux/app/app_state.dart';
+import 'package:meta/meta.dart';
+import 'package:redux/redux.dart';
+
+class HolidayScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => StoreConnector<AppState, _ViewModel>(
+        converter: (Store<AppState> store) {
+          final fetchableHoliday = store.state.holidaySummariesState.fetchableCurrentHoliday;
+          if (fetchableHoliday is FetchableSuccess<Holiday>) {
+            return _ViewModel(fetchableHoliday.object);
+          } else {
+            throw StateError('Unexpected type');
+          }
+        },
+        builder: (BuildContext context, _ViewModel viewModel) => Scaffold(
+              appBar: AppBar(
+                title: Text(viewModel.pageTitle),
+              ),
+              body: Text(viewModel.name + '\n' + viewModel.details),
+            ),
+      );
+}
+
+@immutable
+class _ViewModel {
+  final String pageTitle;
+  final String name;
+  final String details;
+
+  _ViewModel._({@required this.pageTitle, @required this.name, @required this.details});
+
+  factory _ViewModel(Holiday holiday) {
+    return _ViewModel._(pageTitle: 'Holiday', name: holiday.name, details: holiday.details);
+  }
+}

--- a/lib/ui/widgets/spinner.dart
+++ b/lib/ui/widgets/spinner.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+class Spinner extends StatelessWidget {
+  Spinner({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: CircularProgressIndicator(),
+    );
+  }
+}


### PR DESCRIPTION
Now we're getting into the meat of the application. In this PR, we add a new API that can fetch a `Holiday` object (which contains a bit more info than a `HolidaySummary` - not much, but some).

We also add a few more redux actions to signify the ability for users to initiate a fetch for a holiday, receive the holiday details, and to select it (ie. transition into the detailed view).

The `HolidayScreen` itself is super simple and just contains two fields. However, it lets us see how navigating into (and back out of) another screen might look.

Note that the spinner that we present while fetching is pretty ugly. It replaces the whole screen contents, which is a bit jarring... this really should be addressed in a future change to overlay the spinner over the top of the existing content. For now, though, it serves as a indicator of how we might implement this feature.

DIsplaying spinner | DIsplaying holiday detail
:-------------------------:|:-------------------------:
![simulator screen shot - iphone x - 2018-11-19 at 17 41 50](https://user-images.githubusercontent.com/1574429/48690617-72de9380-ec23-11e8-9075-b755f457c1a5.png) | ![simulator screen shot - iphone x - 2018-11-19 at 17 41 52](https://user-images.githubusercontent.com/1574429/48690622-74a85700-ec23-11e8-9a43-0a1a234ddcd8.png)
