### PR TITLE
Simple routes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:holidays/redux/app/app_reducers.dart';
 import 'package:holidays/redux/app/app_state.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_middleware.dart';
-import 'package:holidays/ui/holiday_list/holiday_list_screen.dart';
+import 'package:holidays/routes.dart';
 import 'package:redux/redux.dart';
 
 void main() => runApp(HolidaysApp());
@@ -30,7 +30,8 @@ class HolidaysApp extends StatelessWidget {
           theme: ThemeData(
             primarySwatch: Colors.blue,
           ),
-          home: HolidayListScreen(),
+          routes: getRoutes(context, store),
+          initialRoute: '/',
         ),
       );
 }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_redux/flutter_redux.dart';
+import 'package:holidays/redux/app/app_state.dart';
+import 'package:holidays/ui/holiday/holiday_screen.dart';
+import 'package:holidays/ui/holiday_list/holiday_list_screen.dart';
+import 'package:redux/redux.dart';
+
+Map<String, WidgetBuilder> getRoutes(BuildContext context, Store<AppState> store) {
+  return {
+    '/': (BuildContext context) => new StoreBuilder<AppState>(
+          builder: (context, store) {
+            return HolidayListScreen();
+          },
+        ),
+    '/holiday': (BuildContext context) => new StoreBuilder<AppState>(
+          builder: (context, store) {
+            return HolidayScreen();
+          },
+        ),
+  };
+}

--- a/lib/ui/holiday_list/holiday_list_screen.dart
+++ b/lib/ui/holiday_list/holiday_list_screen.dart
@@ -5,7 +5,6 @@ import 'package:holidays/model/holiday_summary.dart';
 import 'package:holidays/redux/app/app_state.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_state.dart';
-import 'package:holidays/ui/holiday/holiday_screen.dart';
 import 'package:holidays/ui/widgets/spinner.dart';
 import 'package:meta/meta.dart';
 import 'package:redux/redux.dart';
@@ -60,9 +59,7 @@ class HolidayListScreen extends StatelessWidget {
           final action = FetchHolidayAction(summaryViewModel.id);
           store.dispatch(action);
           action.completer.future.then((value) {
-            Navigator.of(context).push(MaterialPageRoute(builder: (context) {
-              return HolidayScreen();
-            }));
+            Navigator.of(context).pushNamed('/holiday');
           });
         });
   }


### PR DESCRIPTION
Rather than pushing screens directly, a more idiomatic method of screen management is to use "routes". So, this PR introduces the concept of using routes instead of pushing screens.

No visible difference for the end user... just a bit of refactoring to set things up for future use.