### PR TITLE
Common holiday navigation

### DIFF
--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,9 +1,18 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:holidays/redux/app/app_state.dart';
+import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
 import 'package:holidays/ui/holiday/holiday_screen.dart';
 import 'package:holidays/ui/holiday_list/holiday_list_screen.dart';
 import 'package:redux/redux.dart';
+
+void navigateToHoliday({@required int id, @required BuildContext context, @required Store<AppState> store}) {
+  final action = FetchHolidayAction(id);
+  store.dispatch(action);
+  action.completer.future.then((result) {
+    Navigator.of(context).pushNamed('/holiday');
+  });
+}
 
 Map<String, WidgetBuilder> getRoutes(BuildContext context, Store<AppState> store) {
   return {

--- a/lib/ui/holiday_list/holiday_list_screen.dart
+++ b/lib/ui/holiday_list/holiday_list_screen.dart
@@ -5,6 +5,7 @@ import 'package:holidays/model/holiday_summary.dart';
 import 'package:holidays/redux/app/app_state.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_state.dart';
+import 'package:holidays/routes.dart';
 import 'package:holidays/ui/widgets/spinner.dart';
 import 'package:meta/meta.dart';
 import 'package:redux/redux.dart';
@@ -56,11 +57,7 @@ class HolidayListScreen extends StatelessWidget {
         ),
         onTap: () {
           final store = StoreProvider.of<AppState>(context);
-          final action = FetchHolidayAction(summaryViewModel.id);
-          store.dispatch(action);
-          action.completer.future.then((value) {
-            Navigator.of(context).pushNamed('/holiday');
-          });
+          navigateToHoliday(id: summaryViewModel.id, context: context, store: store);
         });
   }
 }


### PR DESCRIPTION
An underlying problem in the previous code was that we have a route called `/holiday` that expects our `HolidaySummariesState` redux state to have valid `fetchableCurrentHoliday` variable set. This implicit linkage is a bit brittle. Particularly if we think forward a little about how we might handle deep linking into our app with a specific holiday identifier - there's no guarantee that that code will correctly coordinate the dispatch of `FetchHolidayAction` and the push to the `/holiday` route.

As an interim step towards making this a bit more robust, we create a common function that can be called passing an identifier and that function makes sure the correct sequence of calls are made. There's quite possibly a much better way of doing this by using either `RouteSettings` or a wrapper redux action that coordinates the two steps.

No functional change for this change.