### PR TITLE
Added splash screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:holidays/networking/api.dart';
+import 'package:holidays/redux/app/app_middleware.dart';
 import 'package:holidays/redux/app/app_reducers.dart';
 import 'package:holidays/redux/app/app_state.dart';
-import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
-import 'package:holidays/redux/holiday_list/holiday_list_middleware.dart';
 import 'package:holidays/routes.dart';
+import 'package:holidays/ui/splash/splash_screen.dart';
 import 'package:redux/redux.dart';
 
 void main() => runApp(HolidaysApp());
@@ -14,13 +14,8 @@ class HolidaysApp extends StatelessWidget {
   final Store<AppState> store = Store<AppState>(
     appReducer,
     initialState: AppState.initial(),
-    middleware: createHolidayListMiddleware(API()),
+    middleware: createAppMiddleware(API()),
   );
-
-  HolidaysApp() {
-    // first thing we do when we launch is trigger a fetch of holiday summaries
-    store.dispatch(FetchHolidaySummariesAction());
-  }
 
   @override
   Widget build(BuildContext context) => StoreProvider(
@@ -30,8 +25,8 @@ class HolidaysApp extends StatelessWidget {
           theme: ThemeData(
             primarySwatch: Colors.blue,
           ),
+          home: SplashScreen(),
           routes: getRoutes(context, store),
-          initialRoute: '/',
         ),
       );
 }

--- a/lib/redux/app/app_actions.dart
+++ b/lib/redux/app/app_actions.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+class InitAction {
+  final BuildContext context;
+
+  InitAction(this.context);
+}

--- a/lib/redux/app/app_middleware.dart
+++ b/lib/redux/app/app_middleware.dart
@@ -1,0 +1,29 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:holidays/networking/api.dart';
+import 'package:holidays/redux/app/app_actions.dart';
+import 'package:holidays/redux/app/app_state.dart';
+import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
+import 'package:holidays/redux/holiday_list/holiday_list_middleware.dart';
+import 'package:redux/redux.dart';
+
+List<Middleware<AppState>> createAppMiddleware(API api) {
+  var list = List<Middleware<AppState>>();
+  list.addAll(createHolidayListMiddleware(api));
+  list.add(_splashMiddleware());
+  return list;
+}
+
+Middleware<AppState> _splashMiddleware() {
+  return (Store<AppState> store, action, NextDispatcher next) async {
+    next(action);
+
+    if (action is InitAction) {
+      await Future.delayed(const Duration(seconds: 1));
+
+      store.dispatch(FetchHolidaySummariesAction());
+      Navigator.of(action.context).pushReplacementNamed('/holidayList');
+    }
+  };
+}

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -16,7 +16,7 @@ void navigateToHoliday({@required int id, @required BuildContext context, @requi
 
 Map<String, WidgetBuilder> getRoutes(BuildContext context, Store<AppState> store) {
   return {
-    '/': (BuildContext context) => new StoreBuilder<AppState>(
+    '/holidayList': (BuildContext context) => new StoreBuilder<AppState>(
           builder: (context, store) {
             return HolidayListScreen();
           },

--- a/lib/ui/splash/splash_screen.dart
+++ b/lib/ui/splash/splash_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_redux/flutter_redux.dart';
+import 'package:holidays/redux/app/app_actions.dart';
+import 'package:holidays/redux/app/app_state.dart';
+import 'package:redux/redux.dart';
+
+class SplashScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return StoreBuilder(
+        onInit: (Store<AppState> store) => store.dispatch(InitAction(context)),
+        builder: (BuildContext context, Store<AppState> store) {
+          return Scaffold(body: Center(child: Text('LOGO')));
+        });
+  }
+}


### PR DESCRIPTION
On startup, we often need to do a few things like check to see if the user is logged in or go and fetch some remote configuration. A very common mechanism to do this is to hide this behaviour behind a splash screen of sorts.

In this PR, we create a super simple splash screen (it just contains a label with the text "LOGO" on it), and make it the first screen that the app displays. The `onInit()` function in this screen dispatches an `InitAction`, which will trigger a fetch of the holiday list... this is a nice way to make sure the holiday list is fetched performantly (note that even if the API hasn't returned completely by the time the `HolidayListScreen` is presented, the nice thing is that the holiday list screen just presents the "loading" view while it is waiting).

Splash screen | Main screen (no change)
:-------------------------:|:-------------------------:
![simulator screen shot - iphone x - 2018-11-19 at 19 27 25](https://user-images.githubusercontent.com/1574429/48694728-492c6900-ec31-11e8-9157-4196dd087cb3.png) | ![simulator screen shot - iphone x - 2018-11-19 at 19 29 14](https://user-images.githubusercontent.com/1574429/48694784-6e20dc00-ec31-11e8-9003-6ed2ba82da07.png)
