### PR TITLE
Use globalNavigatorKey instead of passing buildcontext around

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ class HolidaysApp extends StatelessWidget {
         store: store,
         child: MaterialApp(
           title: 'Holidays Demo',
+          navigatorKey: globalNavigatorKey,
           theme: ThemeData(
             primarySwatch: Colors.blue,
           ),

--- a/lib/redux/app/app_actions.dart
+++ b/lib/redux/app/app_actions.dart
@@ -1,13 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
-
 abstract class CompleterAction {
   final Completer completer = Completer();
 }
 
-class InitAction {
-  final BuildContext context;
-
-  InitAction(this.context);
-}
+class InitAction {}

--- a/lib/redux/app/app_middleware.dart
+++ b/lib/redux/app/app_middleware.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:holidays/networking/api.dart';
 import 'package:holidays/redux/app/app_actions.dart';
 import 'package:holidays/redux/app/app_state.dart';
 import 'package:holidays/redux/auth/auth_middleware.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_middleware.dart';
+import 'package:holidays/routes.dart';
 import 'package:redux/redux.dart';
 
 List<Middleware<AppState>> createAppMiddleware(API api) {
@@ -25,7 +25,7 @@ Middleware<AppState> _splashMiddleware() {
       await Future.delayed(const Duration(seconds: 1));
 
       store.dispatch(FetchHolidaySummariesAction());
-      Navigator.of(action.context).pushReplacementNamed('/holidayList');
+      globalNavigatorKey.currentState.pushReplacementNamed('/holidayList');
     }
   };
 }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -6,6 +6,8 @@ import 'package:holidays/ui/holiday/holiday_screen.dart';
 import 'package:holidays/ui/holiday_list/holiday_list_screen.dart';
 import 'package:redux/redux.dart';
 
+final GlobalKey<NavigatorState> globalNavigatorKey = new GlobalKey<NavigatorState>();
+
 void navigateToHoliday({@required int id, @required BuildContext context, @required Store<AppState> store}) {
   final action = FetchHolidayAction(id);
   store.dispatch(action);

--- a/lib/ui/splash/splash_screen.dart
+++ b/lib/ui/splash/splash_screen.dart
@@ -8,7 +8,7 @@ class SplashScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return StoreBuilder(
-        onInit: (Store<AppState> store) => store.dispatch(InitAction(context)),
+        onInit: (Store<AppState> store) => store.dispatch(InitAction()),
         builder: (BuildContext context, Store<AppState> store) {
           return Scaffold(body: Center(child: Text('LOGO')));
         });


### PR DESCRIPTION
We were previously passing around a `BuildContext` via the redux action. I don't feel like this is the worst pattern ever, but I can see it getting a bit verbose in the future.

This PR switches to a new pattern which is to have a global navigator key that can be used to navigate between screens. This also sets us up for some upcoming changes when we need to add support for a bottom tab bar.