### PR TITLE
Login screen hooked up

### DIFF
--- a/lib/redux/app/app_middleware.dart
+++ b/lib/redux/app/app_middleware.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:holidays/model/user.dart';
 import 'package:holidays/networking/api.dart';
 import 'package:holidays/redux/app/app_actions.dart';
 import 'package:holidays/redux/app/app_state.dart';
+import 'package:holidays/redux/auth/auth_actions.dart';
 import 'package:holidays/redux/auth/auth_middleware.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_middleware.dart';
@@ -24,8 +26,15 @@ Middleware<AppState> _splashMiddleware() {
     if (action is InitAction) {
       await Future.delayed(const Duration(seconds: 1));
 
-      store.dispatch(FetchHolidaySummariesAction());
-      globalNavigatorKey.currentState.pushReplacementNamed('/holidayList');
+      final isLoggedIn = false;
+      final loggedInUser = isLoggedIn ? User(name: "john smith", userid: "john") : null;
+      if (loggedInUser != null) {
+        store.dispatch(LoginSuccessfulAction(user: loggedInUser));
+        store.dispatch(FetchHolidaySummariesAction());
+        globalNavigatorKey.currentState.pushReplacementNamed('/holidayList');
+      } else {
+        globalNavigatorKey.currentState.pushReplacementNamed('/login');
+      }
     }
   };
 }

--- a/lib/redux/auth/auth_actions.dart
+++ b/lib/redux/auth/auth_actions.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:holidays/model/user.dart';
 import 'package:holidays/redux/app/app_actions.dart';
 import 'package:meta/meta.dart';

--- a/lib/redux/auth/auth_middleware.dart
+++ b/lib/redux/auth/auth_middleware.dart
@@ -1,6 +1,8 @@
 import 'package:holidays/networking/api.dart';
 import 'package:holidays/redux/app/app_state.dart';
 import 'package:holidays/redux/auth/auth_actions.dart';
+import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
+import 'package:holidays/routes.dart';
 import 'package:redux/redux.dart';
 
 List<Middleware<AppState>> createAuthenticationMiddleware(API api) => [
@@ -9,14 +11,16 @@ List<Middleware<AppState>> createAuthenticationMiddleware(API api) => [
 
 Middleware<AppState> _login(API api) {
   return (Store<AppState> store, action, NextDispatcher next) async {
-    if (action is LoginAction) {
-      next(action);
+    next(action);
 
+    if (action is LoginAction) {
       try {
         final user = await api.login(userid: action.userid, password: action.password);
 
         action.completer.complete();
         store.dispatch(LoginSuccessfulAction(user: user));
+        store.dispatch(FetchHolidaySummariesAction());
+        globalNavigatorKey.currentState.pushReplacementNamed('/holidayList');
       } catch (e) {
         action.completer.completeError(e);
         store.dispatch(LoginFailedAction(error: e));

--- a/lib/redux/auth/auth_reducers.dart
+++ b/lib/redux/auth/auth_reducers.dart
@@ -10,19 +10,18 @@ final authenticationReducer = combineReducers<AuthenticationState>([
 ]);
 
 AuthenticationState _login(AuthenticationState state, LoginAction action) {
-  // no change required when initiating the login
-  return state;
+  return state.copyWith(errorMessage: "");
 }
 
 AuthenticationState _loginSuccessful(AuthenticationState state, LoginSuccessfulAction action) {
-  return state.copyWith(loggedInUser: action.user);
+  return state.copyWith(loggedInUser: action.user, errorMessage: "");
 }
 
 AuthenticationState _loginFailed(AuthenticationState state, LoginFailedAction action) {
   // if we've failed, then we ensure they're logged out
-  return state.copyWith(loggedInUser: null);
+  return state.copyWith(loggedInUser: null, errorMessage: action.error.toString());
 }
 
 AuthenticationState _logout(AuthenticationState state, LogoutAction action) {
-  return state.copyWith(loggedInUser: null);
+  return state.copyWith(loggedInUser: null, errorMessage: "");
 }

--- a/lib/redux/auth/auth_state.dart
+++ b/lib/redux/auth/auth_state.dart
@@ -6,21 +6,28 @@ class AuthenticationState {
   /// The logged in user (can be `null` if no-one is currently logged in)
   final User loggedInUser;
 
+  /// An error message if there was a recent failed attemp
+  final String errorMessage;
+
   AuthenticationState({
     @required this.loggedInUser,
+    @required this.errorMessage,
   });
 
   factory AuthenticationState.initial() {
     return AuthenticationState(
       loggedInUser: null,
+      errorMessage: "",
     );
   }
 
   AuthenticationState copyWith({
     User loggedInUser,
+    String errorMessage,
   }) {
     return AuthenticationState(
       loggedInUser: loggedInUser ?? this.loggedInUser,
+      errorMessage: errorMessage ?? this.errorMessage,
     );
   }
 

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:holidays/redux/app/app_state.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
+import 'package:holidays/ui/auth/login_screen.dart';
 import 'package:holidays/ui/holiday/holiday_screen.dart';
 import 'package:holidays/ui/holiday_list/holiday_list_screen.dart';
 import 'package:redux/redux.dart';
@@ -18,6 +19,11 @@ void navigateToHoliday({@required int id, @required BuildContext context, @requi
 
 Map<String, WidgetBuilder> getRoutes(BuildContext context, Store<AppState> store) {
   return {
+    '/login': (BuildContext context) => new StoreBuilder<AppState>(
+          builder: (context, store) {
+            return LoginScreen();
+          },
+        ),
     '/holidayList': (BuildContext context) => new StoreBuilder<AppState>(
           builder: (context, store) {
             return HolidayListScreen();

--- a/lib/ui/auth/login_screen.dart
+++ b/lib/ui/auth/login_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_redux/flutter_redux.dart';
+import 'package:holidays/redux/app/app_state.dart';
+import 'package:holidays/redux/auth/auth_actions.dart';
+import 'package:redux/redux.dart';
+
+class LoginScreen extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final TextEditingController _useridController = new TextEditingController();
+  final TextEditingController _passwordController = new TextEditingController();
+
+  Widget build(BuildContext context) => StoreConnector<AppState, _ViewModel>(
+      converter: (Store<AppState> store) => _ViewModel.create(store: store),
+      builder: (BuildContext context, _ViewModel viewModel) => Scaffold(
+            appBar: AppBar(title: Text(viewModel.pageTitle)),
+            body: Container(
+              padding: EdgeInsets.all(16.0),
+              child: Column(
+                children: <Widget>[
+                  TextField(
+                    controller: _useridController,
+                    decoration: InputDecoration(labelText: 'Userid'),
+                  ),
+                  TextField(
+                    controller: _passwordController,
+                    decoration: InputDecoration(labelText: 'Password'),
+                  ),
+                  RaisedButton(
+                    child: Text('Login'),
+                    onPressed: () {
+                      viewModel.performLogin(
+                        userid: _useridController.text,
+                        password: _passwordController.text,
+                      );
+                    },
+                  ),
+                  Text(viewModel.errorMessage)
+                ],
+              ),
+            ),
+          ));
+}
+
+class _ViewModel {
+  // the title for the page
+  final String pageTitle;
+  // the error message (can be empty)
+  final String errorMessage;
+  // function that will be called when a login needs to be performed
+  final Function({String userid, String password}) performLogin;
+
+  _ViewModel._({@required this.pageTitle, @required this.errorMessage, @required this.performLogin});
+
+  factory _ViewModel.create({Store<AppState> store}) {
+    return _ViewModel._(
+        pageTitle: 'Login',
+        errorMessage: store.state.authenticationState.errorMessage,
+        performLogin: ({String userid, String password}) {
+          store.dispatch(LoginAction(userid: userid, password: password));
+        });
+  }
+}


### PR DESCRIPTION
In this PR, we add a new login screen (serviced via a `/login` route).

In the middleware we add a new variable called `isLoggedIn` that is hard-coded to false. In a real app, we would set this variable based on whether we have a valid user access token (ie. is the user logged in). For now, though, depending on that flag, we've just got some code that manually creates a user or shows the login screen.

We probably should put a spinner up while we're doing the authentication, but you should be able to figure out how to do that based on the existing `HolidayListScreen` behaviour.

The transition from the login screen to the holiday list is a bit icky (it is a push transition, which implies you can go back), but we will tidy that up in a future change. Also, we can't logout yet...

We also fix an accidential bug in `auth_middleware` where the call to `next()` was previously inside the `if` condition (but it needs to be outside so that the action always gets passed along the middleware chain).

Initial state | Error
:-------------------------:|:-------------------------:
![simulator screen shot - iphone x - 2018-11-21 at 07 54 29](https://user-images.githubusercontent.com/1574429/48802225-b4298d00-ed62-11e8-802e-5b432a47ba00.png) | ![simulator screen shot - iphone x - 2018-11-21 at 07 53 42](https://user-images.githubusercontent.com/1574429/48802228-b5f35080-ed62-11e8-8aa8-beff79a9999f.png)
