### PR TITLE
Logout button

### DIFF
--- a/lib/redux/app/app_middleware.dart
+++ b/lib/redux/app/app_middleware.dart
@@ -26,7 +26,7 @@ Middleware<AppState> _splashMiddleware() {
     if (action is InitAction) {
       await Future.delayed(const Duration(seconds: 1));
 
-      final isLoggedIn = false;
+      final isLoggedIn = true;
       final loggedInUser = isLoggedIn ? User(name: "john smith", userid: "john") : null;
       if (loggedInUser != null) {
         store.dispatch(LoginSuccessfulAction(user: loggedInUser));

--- a/lib/redux/auth/auth_middleware.dart
+++ b/lib/redux/auth/auth_middleware.dart
@@ -7,6 +7,7 @@ import 'package:redux/redux.dart';
 
 List<Middleware<AppState>> createAuthenticationMiddleware(API api) => [
       TypedMiddleware<AppState, LoginAction>(_login(api)),
+      TypedMiddleware<AppState, LogoutAction>(_logout(api)),
     ];
 
 Middleware<AppState> _login(API api) {
@@ -25,6 +26,16 @@ Middleware<AppState> _login(API api) {
         action.completer.completeError(e);
         store.dispatch(LoginFailedAction(error: e));
       }
+    }
+  };
+}
+
+Middleware<AppState> _logout(API api) {
+  return (Store<AppState> store, action, NextDispatcher next) async {
+    next(action);
+
+    if (action is LogoutAction) {
+      globalNavigatorKey.currentState.pushReplacementNamed('/login');
     }
   };
 }

--- a/lib/ui/holiday_list/holiday_list_screen.dart
+++ b/lib/ui/holiday_list/holiday_list_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:holidays/model/fetchable.dart';
 import 'package:holidays/model/holiday_summary.dart';
 import 'package:holidays/redux/app/app_state.dart';
+import 'package:holidays/redux/auth/auth_actions.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_state.dart';
 import 'package:holidays/routes.dart';
@@ -17,6 +18,14 @@ class HolidayListScreen extends StatelessWidget {
         builder: (BuildContext context, _ViewModel viewModel) => Scaffold(
               appBar: AppBar(
                 title: Text(viewModel.pageTitle),
+                actions: <Widget>[
+                  IconButton(
+                    icon: Icon(Icons.backspace),
+                    onPressed: () {
+                      StoreProvider.of<AppState>(context).dispatch(LogoutAction());
+                    },
+                  ),
+                ],
               ),
               body: viewModel.isLoadingHoliday ? Spinner() : _createRefreshWidget(context, viewModel),
             ),


### PR DESCRIPTION
We add an (ugly) button to the app bar of the holiday list screen so that we can log out. When that button is tapped, we dispatch a `LogoutAction`. 

The middleware behaviour for this action is to replace the current screen with the login screen. Note that a previous PR had checked in some code in the auth reducer that (upon dispatch of a `LogoutAction`) sets the logged in user to `null` in the authentication state object.

The last thing that this change does is default the user to being logged in (I got tired of having to log in every time I restarted the app during development ... ha ha)

Logout button | After logout
:-------------------------:|:-------------------------:
![simulator screen shot - iphone x - 2018-11-21 at 08 02 25](https://user-images.githubusercontent.com/1574429/48802611-d1129000-ed63-11e8-90da-dd08bb582df0.png) | ![simulator screen shot - iphone x - 2018-11-21 at 08 02 33](https://user-images.githubusercontent.com/1574429/48802612-d1129000-ed63-11e8-95af-e796c31ef803.png)