### PR TITLE
Added basic tab bar

### DIFF
--- a/lib/redux/app/app_middleware.dart
+++ b/lib/redux/app/app_middleware.dart
@@ -31,7 +31,7 @@ Middleware<AppState> _splashMiddleware() {
       if (loggedInUser != null) {
         store.dispatch(LoginSuccessfulAction(user: loggedInUser));
         store.dispatch(FetchHolidaySummariesAction());
-        globalNavigatorKey.currentState.pushReplacementNamed('/holidayList');
+        globalNavigatorKey.currentState.pushReplacementNamed('/dashboard');
       } else {
         globalNavigatorKey.currentState.pushReplacementNamed('/login');
       }

--- a/lib/redux/auth/auth_middleware.dart
+++ b/lib/redux/auth/auth_middleware.dart
@@ -21,7 +21,7 @@ Middleware<AppState> _login(API api) {
         action.completer.complete();
         store.dispatch(LoginSuccessfulAction(user: user));
         store.dispatch(FetchHolidaySummariesAction());
-        globalNavigatorKey.currentState.pushReplacementNamed('/holidayList');
+        globalNavigatorKey.currentState.pushReplacementNamed('/dashboard');
       } catch (e) {
         action.completer.completeError(e);
         store.dispatch(LoginFailedAction(error: e));

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -3,6 +3,7 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:holidays/redux/app/app_state.dart';
 import 'package:holidays/redux/holiday_list/holiday_list_actions.dart';
 import 'package:holidays/ui/auth/login_screen.dart';
+import 'package:holidays/ui/dashboard/dashboard_screen.dart';
 import 'package:holidays/ui/holiday/holiday_screen.dart';
 import 'package:holidays/ui/holiday_list/holiday_list_screen.dart';
 import 'package:redux/redux.dart';
@@ -22,6 +23,11 @@ Map<String, WidgetBuilder> getRoutes(BuildContext context, Store<AppState> store
     '/login': (BuildContext context) => new StoreBuilder<AppState>(
           builder: (context, store) {
             return LoginScreen();
+          },
+        ),
+    '/dashboard': (BuildContext context) => new StoreBuilder<AppState>(
+          builder: (context, store) {
+            return DashboardScreen();
           },
         ),
     '/holidayList': (BuildContext context) => new StoreBuilder<AppState>(

--- a/lib/ui/dashboard/dashboard_screen.dart
+++ b/lib/ui/dashboard/dashboard_screen.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_redux/flutter_redux.dart';
+import 'package:holidays/redux/app/app_state.dart';
+import 'package:holidays/ui/holiday_list/holiday_list_screen.dart';
+import 'package:holidays/ui/widgets/holidays_navigation_bar.dart';
+import 'package:redux/redux.dart';
+
+class DashboardScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return StoreBuilder(
+      builder: (BuildContext context, Store<AppState> store) {
+        return Scaffold(
+          body: Stack(children: <Widget>[
+            HolidayListScreen(),
+          ]),
+          bottomNavigationBar: HolidaysNavigationBar(
+            currentTab: BottomTab.holidays,
+            onSelectTab: _selectTab,
+          ),
+        );
+      },
+    );
+  }
+
+  void _selectTab(BottomTab tab) {
+    print('Selected $tab');
+  }
+}

--- a/lib/ui/widgets/holidays_navigation_bar.dart
+++ b/lib/ui/widgets/holidays_navigation_bar.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+enum BottomTab { holidays, profile }
+
+class HolidaysNavigationBar extends BottomNavigationBar {
+  final BottomTab currentTab;
+  final ValueChanged<BottomTab> onSelectTab;
+
+  HolidaysNavigationBar({this.currentTab, this.onSelectTab})
+      : super(
+            currentIndex: currentTab.index,
+            type: BottomNavigationBarType.fixed,
+            items: [
+              BottomNavigationBarItem(icon: Icon(Icons.list), title: Text('Holidays')),
+              BottomNavigationBarItem(icon: Icon(Icons.person), title: Text('Profile')),
+            ],
+            onTap: (index) => onSelectTab(BottomTab.values[index]));
+}


### PR DESCRIPTION
In order to add a tab bar at the bottom of the screen, we shift towards the notion of a "dashboard" that contains a tab bar and a currently visible view (based on which tab is selected).

So, we create a new `DashboardScreen` that contains the tab bar and (at the moment) a `HolidayListScreen`. Selecting the tabs makes a callback to the `DashboardScreen._selectTab()` function but at the moment, we just dump out a message to the console. We'll add switching tabs in a future change.

Also, anywhere where we used to navigate to the holiday list (on startup or after successful login), we now need to navigate to the dashboard instead.

The concepts that we've started implementing in this PR are heavily inspired by [this great article](https://medium.com/coding-with-flutter/flutter-case-study-multiple-navigators-with-bottomnavigationbar-90eb6caa6dbf) on using multiple navigators to support multiple, parallel screen hierarchies.

![simulator screen shot - iphone x - 2018-11-21 at 08 26 18](https://user-images.githubusercontent.com/1574429/48806746-70895000-ed6f-11e8-9920-da0b32eea0d9.png)

[View next PR](https://github.com/edwardaux/flutter-holidays-redux/pull/15)