### PR TITLE
Connected profile screen to second tab

### DIFF
--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -6,9 +6,12 @@ import 'package:holidays/ui/auth/login_screen.dart';
 import 'package:holidays/ui/dashboard/dashboard_screen.dart';
 import 'package:holidays/ui/holiday/holiday_screen.dart';
 import 'package:holidays/ui/holiday_list/holiday_list_screen.dart';
+import 'package:holidays/ui/profile/profile_screen.dart';
 import 'package:redux/redux.dart';
 
 final GlobalKey<NavigatorState> globalNavigatorKey = new GlobalKey<NavigatorState>();
+final GlobalKey<NavigatorState> holidaysTabNavigatorKey = new GlobalKey<NavigatorState>();
+final GlobalKey<NavigatorState> profileTabNavigatorKey = new GlobalKey<NavigatorState>();
 
 void navigateToHoliday({@required int id, @required BuildContext context, @required Store<AppState> store}) {
   final action = FetchHolidayAction(id);
@@ -38,6 +41,11 @@ Map<String, WidgetBuilder> getRoutes(BuildContext context, Store<AppState> store
     '/holiday': (BuildContext context) => new StoreBuilder<AppState>(
           builder: (context, store) {
             return HolidayScreen();
+          },
+        ),
+    '/profile': (BuildContext context) => new StoreBuilder<AppState>(
+          builder: (context, store) {
+            return ProfileScreen();
           },
         ),
   };

--- a/lib/ui/dashboard/dashboard_screen.dart
+++ b/lib/ui/dashboard/dashboard_screen.dart
@@ -1,21 +1,32 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:holidays/redux/app/app_state.dart';
-import 'package:holidays/ui/holiday_list/holiday_list_screen.dart';
+import 'package:holidays/routes.dart';
 import 'package:holidays/ui/widgets/holidays_navigation_bar.dart';
+import 'package:holidays/ui/widgets/tab_navigator.dart';
 import 'package:redux/redux.dart';
 
-class DashboardScreen extends StatelessWidget {
+class DashboardScreen extends StatefulWidget {
+  @override
+  DashboardScreenState createState() {
+    return new DashboardScreenState();
+  }
+}
+
+class DashboardScreenState extends State<DashboardScreen> {
+  var currentTab = BottomTab.holidays;
+
   @override
   Widget build(BuildContext context) {
     return StoreBuilder(
       builder: (BuildContext context, Store<AppState> store) {
         return Scaffold(
           body: Stack(children: <Widget>[
-            HolidayListScreen(),
+            _buildOffstageNavigator(BottomTab.holidays, '/holidayList', holidaysTabNavigatorKey),
+            _buildOffstageNavigator(BottomTab.profile, '/profile', profileTabNavigatorKey),
           ]),
           bottomNavigationBar: HolidaysNavigationBar(
-            currentTab: BottomTab.holidays,
+            currentTab: currentTab,
             onSelectTab: _selectTab,
           ),
         );
@@ -23,7 +34,20 @@ class DashboardScreen extends StatelessWidget {
     );
   }
 
+  Widget _buildOffstageNavigator(BottomTab bottomTab, String initialRoute, GlobalKey<NavigatorState> navigatorKey) {
+    return Offstage(
+      offstage: currentTab != bottomTab,
+      child: TabNavigator(
+        bottomTab: bottomTab,
+        initialRoute: initialRoute,
+        navigatorKey: navigatorKey,
+      ),
+    );
+  }
+
   void _selectTab(BottomTab tab) {
-    print('Selected $tab');
+    setState(() {
+      currentTab = tab;
+    });
   }
 }

--- a/lib/ui/widgets/tab_navigator.dart
+++ b/lib/ui/widgets/tab_navigator.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_redux/flutter_redux.dart';
+import 'package:holidays/redux/app/app_state.dart';
+import 'package:holidays/routes.dart';
+import 'package:holidays/ui/widgets/holidays_navigation_bar.dart';
+
+class TabNavigator extends StatelessWidget {
+  final GlobalKey<NavigatorState> navigatorKey;
+  final BottomTab bottomTab;
+  final String initialRoute;
+
+  TabNavigator({@required this.navigatorKey, @required this.bottomTab, @required this.initialRoute});
+
+  @override
+  Widget build(BuildContext context) {
+    final store = StoreProvider.of<AppState>(context);
+    var routes = getRoutes(context, store);
+
+    return Navigator(
+        key: navigatorKey,
+        initialRoute: initialRoute,
+        onGenerateRoute: (routeSettings) {
+          // on the first pass through, the default route ('/') will be passed. however,
+          // because this navigator is managing nested routes (and never the '/' route)
+          // we need to ensure it only returns routes that are meaningful. so, in this
+          // case, we just return the initial route that this navigator was provided with
+          final routeName = (routeSettings.name == '/' ? initialRoute : routeSettings.name);
+          return MaterialPageRoute(builder: (context) => routes[routeName](context));
+        });
+  }
+}


### PR DESCRIPTION
In this PR, we create a new route representing the profile screen, and two additional navigators (`holidaysTabNavigatorKey ` and `profileTabNavigatorKey `) to manage the screen stack for each tab.

We also change `DashboardScreen` to be a stateful widget instead of stateless, so we can keep track of the currently selected tab (`currentTab`). 

Each tab's views are now managed by the two custom navigators I mentioned above, with `currentTab` controlling whether they are rendered or not (via the `Offstage` widget).

The pattern of using multiple navigators/offstage widgets to maintain multiple, parallel screen hierarchies comes from (this great article)[https://medium.com/coding-with-flutter/flutter-case-study-multiple-navigators-with-bottomnavigationbar-90eb6caa6dbf]. Well worth a read!

The screenshots below show what the screen looks like when the holiday list and profile tabs are selected. Note that they both display a back chevron (top left)... this is a bug and will be corrected in a future PR.

Holiday List | Profile
:-------------------------:|:-------------------------:
![simulator screen shot - iphone x - 2018-11-21 at 18 35 06](https://user-images.githubusercontent.com/1574429/48826186-c553b780-edbd-11e8-887a-91726282f0d5.png) | ![simulator screen shot - iphone x - 2018-11-21 at 18 35 10](https://user-images.githubusercontent.com/1574429/48826203-cc7ac580-edbd-11e8-8254-53f62fa9b875.png)
