### PR TITLE
Don't show back button for root screens in tabs

### DIFF
--- a/lib/ui/holiday_list/holiday_list_screen.dart
+++ b/lib/ui/holiday_list/holiday_list_screen.dart
@@ -17,6 +17,7 @@ class HolidayListScreen extends StatelessWidget {
         converter: (Store<AppState> store) => _ViewModel.create(store.state.holidaySummariesState),
         builder: (BuildContext context, _ViewModel viewModel) => Scaffold(
               appBar: AppBar(
+                automaticallyImplyLeading: false,
                 title: Text(viewModel.pageTitle),
                 actions: <Widget>[
                   IconButton(

--- a/lib/ui/profile/profile_screen.dart
+++ b/lib/ui/profile/profile_screen.dart
@@ -17,6 +17,7 @@ class ProfileScreen extends StatelessWidget {
         },
         builder: (BuildContext context, _ViewModel viewModel) => Scaffold(
               appBar: AppBar(
+                automaticallyImplyLeading: false,
                 title: Text(viewModel.pageTitle),
               ),
               body: Text(viewModel.name),


### PR DESCRIPTION
This fixes the defect mentioned in the [previous PR](https://github.com/edwardaux/flutter-holidays-redux/pull/16) where a spurious back button was being displayed.

To be totally truthful, I'm not 100% sure why this fixes this. I did a lot of googling, and this certainly seems to be the most commonly suggested solution, however I am not totally convinced. I hate not really understanding why something works the way it does, so if you can explain why (or can offer a better alternative), I'd love to [hear from you](https://twitter.com/edwardaux).

Holiday List | Profile
:-------------------------:|:-------------------------:
![simulator screen shot - iphone x - 2018-11-21 at 18 52 35](https://user-images.githubusercontent.com/1574429/48826533-aa357780-edbe-11e8-9fca-fc7014f11e7a.png) | ![simulator screen shot - iphone x - 2018-11-21 at 18 52 37](https://user-images.githubusercontent.com/1574429/48826539-b15c8580-edbe-11e8-83c2-b32813e4e2ba.png)