### PR TITLE
Make login scren be modal

### DIFF
--- a/lib/redux/app/app_middleware.dart
+++ b/lib/redux/app/app_middleware.dart
@@ -33,7 +33,7 @@ Middleware<AppState> _splashMiddleware() {
         store.dispatch(FetchHolidaySummariesAction());
         globalNavigatorKey.currentState.pushReplacementNamed('/dashboard');
       } else {
-        globalNavigatorKey.currentState.pushReplacementNamed('/login');
+        displayLoginScreen();
       }
     }
   };

--- a/lib/redux/auth/auth_middleware.dart
+++ b/lib/redux/auth/auth_middleware.dart
@@ -35,7 +35,7 @@ Middleware<AppState> _logout(API api) {
     next(action);
 
     if (action is LogoutAction) {
-      globalNavigatorKey.currentState.pushReplacementNamed('/login');
+      displayLoginScreen();
     }
   };
 }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:holidays/redux/app/app_state.dart';
@@ -21,13 +22,21 @@ void navigateToHoliday({@required int id, @required BuildContext context, @requi
   });
 }
 
+// it annoys me that we have to pull this out into a separate function
+// instead of being able to invoke `.pushReplacementNamed('/login')` like
+// we can do with the rest of the routes. However, I haven't been able to
+// find a way to push with the route name, yet still go modal.
+void displayLoginScreen() {
+  globalNavigatorKey.currentState.pushReplacement(new MaterialPageRoute<Null>(
+    builder: (BuildContext context) {
+      return LoginScreen();
+    },
+    fullscreenDialog: true,
+  ));
+}
+
 Map<String, WidgetBuilder> getRoutes(BuildContext context, Store<AppState> store) {
   return {
-    '/login': (BuildContext context) => new StoreBuilder<AppState>(
-          builder: (context, store) {
-            return LoginScreen();
-          },
-        ),
     '/dashboard': (BuildContext context) => new StoreBuilder<AppState>(
           builder: (context, store) {
             return DashboardScreen();

--- a/lib/ui/auth/login_screen.dart
+++ b/lib/ui/auth/login_screen.dart
@@ -16,10 +16,11 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) => StoreConnector<AppState, _ViewModel>(
       converter: (Store<AppState> store) => _ViewModel.create(store: store),
       builder: (BuildContext context, _ViewModel viewModel) => Scaffold(
-            appBar: AppBar(title: Text(viewModel.pageTitle)),
             body: Container(
               padding: EdgeInsets.all(16.0),
               child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
                 children: <Widget>[
                   TextField(
                     controller: _useridController,


### PR DESCRIPTION
It has annoyed me from the beginning that the login screen would always push in from the right and contained an app bar. A more typical pattern is to have a modal screen with no tab bar.

This change removes the app bar from the login screen (and centres the userid/password while we are at it). 

It also introduces a new function called `displayLoginScreen()` that performs the modal transition. To be honest, this is also a bit annoying... I would prefer that we can just ask the navigator to present the `/login` route modally instead of via a push. However, I have not found a way to do that. The only way I can find is to create a new `MaterialPageRoute` which has a parameter called `fullscreenDialog` that will present the screen modally.

This feels like it can be improved, but given that very places will need to present the login screen, it isn't too bad a compromise. If you know of a better way to be able to use the existing navigator and a route name, please [let me know](https://twitter.com/edwardaux).

Original screen | New screen
:-------------------------:|:-------------------------:
![simulator screen shot - iphone x - 2018-11-21 at 19 00 16](https://user-images.githubusercontent.com/1574429/48827194-a571c300-edc0-11e8-9cfd-cb86fe5f2d68.png) | ![simulator screen shot - iphone x - 2018-11-21 at 19 01 18](https://user-images.githubusercontent.com/1574429/48827198-a86cb380-edc0-11e8-8bc7-6b49674c495a.png)

This ends the series. I hope you enjoyed it as much as I enjoyed building it. If you have any questions, comments or suggestions I would [love to hear from you](https://twitter.com/edwardaux).

[Back to home page](https://github.com/edwardaux/flutter-holidays-redux)
